### PR TITLE
IPC消息传递会解包Buffer对象，导致Buffer无法发送，加入打包操作

### DIFF
--- a/agent.js
+++ b/agent.js
@@ -52,6 +52,9 @@ class AppBootHook {
 
     // 注册mqtt的publish事件
     this.agent.messenger.on('mqtt-publish', data => {
+      if (data.message.type === 'Buffer') {
+        data.message = Buffer.from(data.message.data);
+      }
       this.agent.mqtt.publish(data.topic, data.message, data.options, err => {
         this.agent.coreLogger.error('[egg-mqtt-plugin] publish error : %s', err);
         this.agent.messenger.sendTo(data.pid, data.action, err);


### PR DESCRIPTION
利用mqtt发送Buffer对象的时候，会崩溃，因为egg IPC会把data.message的Buffer对象，解包成{type：‘Buffer’，data：uint8[]}的data.message对象，所以不能直接传送data.message，需要进行打包处理
